### PR TITLE
Synced themes

### DIFF
--- a/index.less
+++ b/index.less
@@ -5,3 +5,9 @@
 
 @import 'editor';
 @import 'language';
+
+@import 'languages/cs';
+@import 'languages/gfm';
+@import 'languages/java';
+@import 'languages/ruby';
+@import 'languages/python';

--- a/index.less
+++ b/index.less
@@ -7,7 +7,9 @@
 @import 'language';
 
 @import 'languages/cs';
+@import 'languages/css';
 @import 'languages/gfm';
 @import 'languages/java';
+@import 'languages/json';
 @import 'languages/ruby';
 @import 'languages/python';

--- a/spec/css.css
+++ b/spec/css.css
@@ -24,3 +24,11 @@ li[lang=ru] {
   color: #F0F0F0 !important;
   width: 100%;
 }
+
+
+/* Tests */
+
+.support-test {
+  background: blue; /* <- valid properties/values should be highlighted more */
+  invalid-property: invalid-color; /* <- invalid should be toned down */
+}

--- a/spec/groovy.groovy
+++ b/spec/groovy.groovy
@@ -1,0 +1,76 @@
+package com.somedomain.here
+
+import java.io.File
+import java.util.List
+
+import static java.io.File.*
+
+/**
+ * Class <b>JAVA</b> Doc
+ *
+ * @author Some Important Person
+ */
+@Awesome("yeah baby!")
+public class Foo<T extends List> extends Bar<T> implements SomeInterface {
+
+  private static final int COUNT = 0x243
+  private def myCount = 0
+
+  public String myProperty = "value"
+
+  @Cool(reason="because")
+  public static staticMethod(String[] values, int n) {
+    try {
+      System.out.print(values[0])
+    } catch (Exception e) {
+      e.printStackTrace()
+    }
+
+    if (n > 0) {
+      return COUNT // single line comment
+    } else {
+      return -COUNT
+    }
+  }
+
+  public Foo(int count) {
+    myCount = count
+  }
+
+  /* This is a multiple...
+      ...line comment. */
+
+  public int getMyCount() throws MyFavoriteException {
+    return myCount
+  }
+
+  /**
+   * Increment the count
+   * @param by the amount to increment by
+   */
+  public void increment(int by) {
+    myCount += by
+  }
+
+  public String describe() {
+    switch (myCount) {
+      case 0: return "0"
+      case 1: return "1"
+      default: return "other"
+    }
+  }
+
+  public MyFooInterface createFooBar() {
+    final String test = null
+
+    return new MyFooInterface() {
+      public boolean isValid() {
+        return false
+      }
+    }
+  }
+
+  public static interface MyFooInterface {
+    public boolean isValid()
+  }
+}

--- a/spec/java.java
+++ b/spec/java.java
@@ -1,0 +1,74 @@
+package com.somedomain.here;
+
+import java.io.File;
+import java.util.List;
+
+import static java.io.File.*;
+
+/**
+ * Class <b>JAVA</b> Doc
+ *
+ * @author Some Important Person
+ */
+@Awesome("yeah baby!")
+public class Foo<T extends List> extends Bar<T> implements SomeInterface {
+
+  private static final int COUNT = 0x243;
+  private int myCount = 0;
+
+  @Cool(reason="because")
+  public static staticMethod(String[] values, int n) {
+    try {
+      System.out.print(values[0]);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    if (n > 0) {
+      return COUNT; // single line comment
+    } else {
+      return -COUNT;
+    }
+  }
+
+  public Foo(int count) {
+    myCount = count;
+  }
+
+  /* This is a multiple...
+      ...line comment. */
+
+  public int getMyCount() throws MyFavoriteException {
+    return myCount;
+  }
+
+  /**
+   * Increment the count
+   * @param by the amount to increment by
+   */
+  public void increment(int by) {
+    myCount += by;
+  }
+
+  public String describe() {
+    switch (myCount) {
+      case 0: return "0";
+      case 1: return "1";
+      default: return "other";
+    }
+  }
+
+  public MyFooInterface createFooBar() {
+    final String test = null;
+
+    return new MyFooInterface() {
+      public boolean isValid() {
+        return false;
+      }
+    }
+  }
+
+  public static interface MyFooInterface {
+    public boolean isValid();
+  }
+}

--- a/spec/json.json
+++ b/spec/json.json
@@ -6,7 +6,19 @@
   },
   {
     "title": "oranges",
-    "count": [17500, null],
-    "description": {"text": "...", "sensitive": false}
+    "count": [17500, null, "String"],
+    "description": {"text": "She said, \"Hello\"", "sensitive": false}
+  },
+  {
+    "deeply_nested": {
+      "key": {
+        "key": {
+          "key": {
+            "array": [1, "two", null],
+            "string": "hello"
+          }
+        }
+      }
+    }
   }
 ]

--- a/spec/php.php
+++ b/spec/php.php
@@ -1,0 +1,5 @@
+<?php
+  public function name($something, $other) {
+
+  }
+?>

--- a/spec/properties.properties
+++ b/spec/properties.properties
@@ -2,3 +2,4 @@
 user=root
 schedule=* * 3 * * *
 retries=4
+dotted.property=true

--- a/spec/properties.properties
+++ b/spec/properties.properties
@@ -1,0 +1,4 @@
+# This is a commment
+user=root
+schedule=* * 3 * * *
+retries=4

--- a/spec/python.py
+++ b/spec/python.py
@@ -1,0 +1,17 @@
+@requires_authorization
+def somefunc(param1='', param2=0):
+    r'''A docstring'''
+    if param1 > param2: # interesting
+        print 'Gre\'ater'
+    return (param2 - param1 + 1) or None
+
+class SomeClass:
+    def cats(arg):
+        abc = 1
+        deg = [1, 2, '3']
+
+    def another(arg):
+        pass
+
+>>> message = '''interpreter
+... prompt'''

--- a/spec/yaml.yml
+++ b/spec/yaml.yml
@@ -1,0 +1,15 @@
+root:
+  unquoted_string: lorem ipsem
+  quotwed_string: "lorem ipsum"
+  integer: 123
+  float: 3.14
+  boolean: true
+  null: null
+  list:
+    - one
+    - two
+    - three
+  map_list:
+    - one: 1
+    - two: "two"
+    - three: 3.0

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -6,24 +6,24 @@
 
 // Base colors -----------------------------------
 @syntax-accent: hsl(@syntax-hue, 100%, 66% );
-@syntax-guide:  fade(@syntax-fg, 40%);
+@syntax-guide:  fade(@syntax-fg, 16%);
 @syntax-fg:     @mono-1;
 @syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
 
 
 // Colors -----------------------------------
 
-@mono-1: hsl(@syntax-hue, 8%, 28%);
-@mono-2: hsl(@syntax-hue, 6%, 48%);
-@mono-3: hsl(@syntax-hue, 4%, 72%);
+@mono-1: hsl(@syntax-hue, 8%, 24%);
+@mono-2: hsl(@syntax-hue, 6%, 44%);
+@mono-3: hsl(@syntax-hue, 4%, 64%);
 
 @hue-1:   hsl(198, 99%, 37%);
 @hue-2:   hsl(221, 87%, 60%);
-@hue-3:   hsl(286, 94%, 57%);
+@hue-3:   hsl(301, 63%, 40%);
 @hue-4:   hsl(119, 34%, 47%);
 
 @hue-5:   hsl(  5, 74%, 59%);
 @hue-5-2: hsl(344, 84%, 43%);
 
-@hue-6:   hsl(48, 87%, 42%);
-@hue-6-2: hsl(41, 99%, 46%);
+@hue-6:   hsl(41, 99%, 30%);
+@hue-6-2: hsl(41, 99%, 38%);

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -1,12 +1,12 @@
 
 // Config -----------------------------------
 @syntax-hue:          230;
-@syntax-saturation:   10%;
+@syntax-saturation:    1%;
 @syntax-brightness:   98%;
 
 // Base colors -----------------------------------
 @syntax-accent: hsl(@syntax-hue, 100%, 66% );
-@syntax-guide:  fade(@syntax-fg, 16%);
+@syntax-guide:  fade(@syntax-fg, 20%);
 @syntax-fg:     @mono-1;
 @syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
 

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -11,19 +11,19 @@
 @syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
 
 
-// Colors -----------------------------------
-
+// Monochrome -----------------------------------
 @mono-1: hsl(@syntax-hue, 8%, 24%);
 @mono-2: hsl(@syntax-hue, 6%, 44%);
 @mono-3: hsl(@syntax-hue, 4%, 64%);
 
-@hue-1:   hsl(198, 99%, 37%);
-@hue-2:   hsl(221, 87%, 60%);
-@hue-3:   hsl(301, 63%, 40%);
-@hue-4:   hsl(119, 34%, 47%);
+// Colors -----------------------------------
+@hue-1:   hsl(198, 99%, 37%); // <-cyan
+@hue-2:   hsl(221, 87%, 60%); // <-blue
+@hue-3:   hsl(301, 63%, 40%); // <-purple
+@hue-4:   hsl(119, 34%, 47%); // <-green
 
-@hue-5:   hsl(  5, 74%, 59%);
-@hue-5-2: hsl(344, 84%, 43%);
+@hue-5:   hsl(  5, 74%, 59%); // <-red 1
+@hue-5-2: hsl(344, 84%, 43%); // <-red 2
 
-@hue-6:   hsl(41, 99%, 30%);
-@hue-6-2: hsl(41, 99%, 38%);
+@hue-6:   hsl(41, 99%, 30%); // <-orange 1
+@hue-6-2: hsl(41, 99%, 38%); // <-orange 2

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -1,37 +1,29 @@
 
 // Config -----------------------------------
-@syntax-hue:          220;
-@syntax-saturation:   0.1%;
+@syntax-hue:          230;
+@syntax-saturation:   10%;
 @syntax-brightness:   98%;
 
 // Base colors -----------------------------------
-@syntax-base-accent-color:      hsl(@syntax-hue, 100%, 66% );
-@syntax-base-background-color:  hsv(@syntax-hue, @syntax-saturation, @syntax-brightness);
-@syntax-base-text-color:        @dark-gray;
-@syntax-base-guide-color:       fade(@syntax-base-text-color, 40%);
+@syntax-accent: hsl(@syntax-hue, 100%, 66% );
+@syntax-guide:  fade(@syntax-fg, 40%);
+@syntax-fg:     @mono-1;
+@syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
 
 
-// Colors: Mix Base16 Atelier Dune with Theme hue -----------------------------------
-@syntax-mix-grey:    -12%;
-@syntax-mix-color:    16%;
-@syntax-mix-contrast: 12%;
+// Colors -----------------------------------
 
-// Grayscale
-@black:           darken( saturate( #20201d, @syntax-mix-grey ), @syntax-mix-contrast ); // 00
-@light-black:     darken( saturate( #292824, @syntax-mix-grey ), @syntax-mix-contrast ); // 01
-@very-dark-gray:  darken( saturate( #6e6b5e, @syntax-mix-grey ), @syntax-mix-contrast ); // 02
-@dark-gray:       darken( saturate( #7d7a68, @syntax-mix-grey ), @syntax-mix-contrast ); // 03
-@gray:            darken( saturate( #999580, @syntax-mix-grey ), @syntax-mix-contrast ); // 04
-@light-gray:      darken( saturate( #a6a28c, @syntax-mix-grey ), @syntax-mix-contrast ); // 05
-@very-light-gray: darken( saturate( #e8e4cf, @syntax-mix-grey ), @syntax-mix-contrast ); // 06
-@white:           darken( saturate( #fefbec, @syntax-mix-grey ), @syntax-mix-contrast ); // 07
+@mono-1: hsl(@syntax-hue, 8%, 28%);
+@mono-2: hsl(@syntax-hue, 6%, 48%);
+@mono-3: hsl(@syntax-hue, 4%, 72%);
 
-// Colors
-@red:             darken( saturate( #d73737, @syntax-mix-color ), @syntax-mix-contrast ); // 08
-@orange:          darken( saturate( #b65611, @syntax-mix-color ), @syntax-mix-contrast ); // 09
-@light-orange:    darken( saturate( #cfb017, @syntax-mix-color ), @syntax-mix-contrast ); // 0A
-@green:           darken( saturate( #60ac39, @syntax-mix-color ), @syntax-mix-contrast ); // 0B
-@cyan:            darken( saturate( #1fad83, @syntax-mix-color ), @syntax-mix-contrast ); // 0C
-@blue:            darken( saturate( #6684e1, @syntax-mix-color ), @syntax-mix-contrast ); // 0D
-@purple:          darken( saturate( #b854d4, @syntax-mix-color ), @syntax-mix-contrast ); // 0E
-@dark-red:        darken( saturate( #d43552, @syntax-mix-color ), @syntax-mix-contrast ); // 0F
+@hue-1:   hsl(198, 99%, 37%);
+@hue-2:   hsl(221, 87%, 60%);
+@hue-3:   hsl(286, 94%, 57%);
+@hue-4:   hsl(119, 34%, 47%);
+
+@hue-5:   hsl(  5, 74%, 59%);
+@hue-5-2: hsl(344, 84%, 43%);
+
+@hue-6:   hsl(48, 87%, 42%);
+@hue-6-2: hsl(41, 99%, 46%);

--- a/styles/language.less
+++ b/styles/language.less
@@ -24,7 +24,7 @@
   }
 
   &.operator {
-    color: @syntax-text-color;
+    color: @mono-1;
   }
 
   &.other.special-method {
@@ -49,7 +49,7 @@
   &.modifier {
     &.package,
     &.import {
-      color: @syntax-text-color;
+      color: @mono-1;
     }
   }
 }
@@ -86,7 +86,7 @@
   }
 
   &.parameter {
-    color: @syntax-text-color;
+    color: @mono-1;
   }
 }
 
@@ -124,7 +124,7 @@
     &.separator,
     &.seperator,
     &.array {
-      color: @syntax-text-color;
+      color: @mono-1;
     }
 
     &.heading,
@@ -151,7 +151,7 @@
     &.method,
     &.class,
     &.inner-class {
-      color: @syntax-text-color;
+      color: @mono-1;
     }
   }
 }
@@ -202,13 +202,13 @@
     color: @hue-6-2;
 
     &.body {
-      color: @syntax-text-color;
+      color: @mono-1;
     }
   }
 
   &.method-call,
   &.method {
-    color: @syntax-text-color;
+    color: @mono-1;
   }
 
   &.definition {
@@ -231,16 +231,16 @@
 
   &.separator {
     background-color: #373b41;
-    color: @syntax-text-color;
+    color: @mono-1;
   }
 
   &.tag {
-    color: @syntax-text-color;
+    color: @mono-1;
   }
 }
 
 .none {
-  color: @syntax-text-color;
+  color: @mono-1;
 }
 
 // Languages -------------------------------------------------

--- a/styles/language.less
+++ b/styles/language.less
@@ -1,26 +1,26 @@
-
 // Language syntax highlighting
 
 .comment {
-  color: @light-gray;
+  color: @mono-3;
   font-style: italic;
 }
 
 .entity {
+
   &.name.type {
-    color: @light-orange;
+    color: @hue-6-2;
   }
 
   &.other.inherited-class {
-    color: @green;
+    color: @hue-4;
   }
 }
 
 .keyword {
-  color: @purple;
+  color: @hue-3;
 
   &.control {
-    color: @purple;
+    color: @hue-3;
   }
 
   &.operator {
@@ -28,154 +28,205 @@
   }
 
   &.other.special-method {
-    color: @blue;
+    color: @hue-2;
   }
 
   &.other.unit {
-    color: @orange;
+    color: @hue-6;
   }
 }
 
 .storage {
-  color: @purple;
+  color: @hue-3;
+
+  &.type {
+    &.annotation,
+    &.primitive {
+      color: @hue-3;
+    }
+  }
+
+  &.modifier {
+    &.package,
+    &.import {
+      color: @syntax-text-color;
+    }
+  }
 }
 
 .constant {
-  color: @orange;
+  color: @hue-6;
+
+  &.variable {
+    color: @hue-6;
+  }
 
   &.character.escape {
-    color: @cyan;
+    color: @hue-1;
   }
 
   &.numeric {
-    color: @orange;
+    color: @hue-6;
   }
 
   &.other.color {
-    color: @cyan;
+    color: @hue-1;
   }
 
   &.other.symbol {
-    color: @cyan;
+    color: @hue-1;
   }
 }
 
 .variable {
-  color: @red;
+  color: @hue-5;
 
   &.interpolation {
-    color: @dark-red;
+    color: @hue-5-2;
   }
 
-  &.parameter.function {
+  &.parameter {
     color: @syntax-text-color;
   }
 }
 
 .invalid.illegal {
-  background-color: @red;
+  background-color: @hue-5;
   color: @syntax-background-color;
 }
 
 .string {
-  color: @green;
+  color: @hue-4;
+
 
   &.regexp {
-    color: @cyan;
+    color: @hue-1;
+
+    .source.ruby.embedded {
+      color: @hue-6-2;
+    }
   }
 
   &.other.link {
-    color: @red;
+    color: @hue-5;
   }
 }
 
 .punctuation {
   &.definition {
     &.comment {
-      color: @light-gray;
+      color: @mono-3;
     }
 
+    &.method-parameters,
+    &.function-parameters,
     &.parameters,
+    &.separator,
+    &.seperator,
     &.array {
       color: @syntax-text-color;
     }
 
     &.heading,
     &.identity {
-      color: @blue;
+      color: @hue-2;
     }
 
     &.bold {
-      color: @light-orange;
+      color: @hue-6-2;
       font-weight: bold;
     }
 
     &.italic {
-      color: @purple;
+      color: @hue-3;
       font-style: italic;
     }
   }
 
-  &.section.embedded {
-    color: @dark-red;
+  &.section {
+    &.embedded {
+      color: @hue-5-2;
+    }
+
+    &.method,
+    &.class,
+    &.inner-class {
+      color: @syntax-text-color;
+    }
   }
 }
 
 .support {
   &.class {
-    color: @light-orange;
+    color: @hue-6-2;
   }
 
   &.function  {
-    color: @cyan;
+    color: @hue-1;
 
     &.any-method {
-      color: @blue;
+      color: @hue-2;
     }
   }
 }
 
 .entity {
   &.name.function {
-    color: @blue;
+    color: @hue-2;
   }
 
-  &.name.class, &.name.type.class {
-    color: @light-orange;
+  &.name.class,
+  &.name.type.class {
+    color: @hue-6-2;
   }
 
   &.name.section {
-    color: @blue;
+    color: @hue-2;
   }
 
   &.name.tag {
-    color: @red;
+    color: @hue-5;
   }
 
   &.other.attribute-name {
-    color: @orange;
+    color: @hue-6;
 
     &.id {
-      color: @blue;
+      color: @hue-2;
     }
   }
 }
 
 .meta {
   &.class {
-    color: @light-orange;
+    color: @hue-6-2;
+
+    &.body {
+      color: @syntax-text-color;
+    }
+  }
+
+  &.method-call,
+  &.method {
+    color: @syntax-text-color;
+  }
+
+  &.definition {
+    &.variable {
+      color: @hue-5;
+    }
   }
 
   &.link {
-    color: @orange;
+    color: @hue-6;
   }
 
   &.require {
-    color: @blue;
+    color: @hue-2;
   }
 
   &.selector {
-    color: @purple;
+    color: @hue-3;
   }
 
   &.separator {
@@ -192,68 +243,44 @@
   color: @syntax-text-color;
 }
 
-
 // Languages -------------------------------------------------
 
 .markup {
   &.bold {
-    color: @orange;
+    color: @hue-6;
     font-weight: bold;
   }
 
   &.changed {
-    color: @purple;
+    color: @hue-3;
   }
 
   &.deleted {
-    color: @red;
+    color: @hue-5;
   }
 
   &.italic {
-    color: @purple;
+    color: @hue-3;
     font-style: italic;
   }
 
   &.heading .punctuation.definition.heading {
-    color: @blue;
+    color: @hue-2;
   }
 
   &.inserted {
-    color: @green;
+    color: @hue-4;
   }
 
   &.list {
-    color: @red;
+    color: @hue-5;
   }
 
   &.quote {
-    color: @orange;
+    color: @hue-6;
   }
 
   &.raw.inline {
-    color: @green;
-  }
-}
-
-.source.gfm {
-  .markup {
-    -webkit-font-smoothing: auto;
-    &.heading {
-      color: @red;
-    }
-
-    &.link {
-      color: @blue;
-    }
-  }
-
-  .link .entity {
-    color: @cyan;
-  }
-}
-
-.ruby {
-  &.symbol > .punctuation {
-    color: inherit;
+    color: @hue-4;
   }
 }

--- a/styles/languages/cs.less
+++ b/styles/languages/cs.less
@@ -1,0 +1,5 @@
+.source.cs {
+  .keyword.operator {
+    color: @hue-3;
+  }
+}

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -1,0 +1,12 @@
+.source.css {
+
+  // highlight properties/values if they are supported
+  .property-name,
+  .property-value {
+    color: @mono-2;
+    &.support {
+      color: @mono-1;
+    }
+  }
+
+}

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -1,0 +1,16 @@
+.source.gfm {
+  .markup {
+    -webkit-font-smoothing: auto;
+    &.heading {
+      color: @hue-5;
+    }
+
+    &.link {
+      color: @hue-3;
+    }
+  }
+
+  .link .entity {
+    color: @hue-2;
+  }
+}

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -9,3 +9,13 @@
     }
   }
 }
+
+.source.java-properties {
+  .meta.key-pair {
+    color: @hue-5;
+
+    & > .punctuation {
+      color: @mono-1;
+    }
+  }
+}

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -1,0 +1,11 @@
+.source.java {
+  .storage {
+    &.modifier.import {
+      color: @hue-6-2;
+    }
+
+    &.type {
+      color: @hue-6-2;
+    }
+  }
+}

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,12 +1,21 @@
 .source.json {
   .meta.structure.dictionary.json {
-    & > .string.quoted.json, .punctuation.string {
+    & > .string.quoted.json {
+      & > .punctuation.string {
+        color: @hue-5;
+      }
       color: @hue-5;
     }
+  }
 
+  .meta.structure.dictionary.json, .meta.structure.array.json {
     & > .value.json > .string.quoted.json,
     & > .value.json > .string.quoted.json > .punctuation {
       color: @hue-4;
+    }
+
+    & > .constant.language.json {
+      color: @hue-1;
     }
   }
 }

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,0 +1,12 @@
+.source.json {
+  .meta.structure.dictionary.json {
+    & > .string.quoted.json, .punctuation.string {
+      color: @hue-5;
+    }
+
+    & > .value.json > .string.quoted.json,
+    & > .value.json > .string.quoted.json > .punctuation {
+      color: @hue-4;
+    }
+  }
+}

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -1,0 +1,9 @@
+.source.python {
+  .keyword.operator.logical.python {
+    color: @hue-3;
+  }
+
+  .variable.parameter {
+    color: @hue-6;
+  }
+}

--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -1,0 +1,5 @@
+.source.ruby {
+  .constant.other.symbol > .punctuation {
+    color: inherit;
+  }
+}

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -3,7 +3,7 @@
 // Custom Syntax Variables -----------------------------------
 
 @syntax-cursor-line: fade(@syntax-fg, 4%); // needs to be semi-transparent to show serach results
-@syntax-bracket-matcher-background-color: saturate(darken(@syntax-bg, 4%), 60%);
+@syntax-bracket-matcher-background-color: saturate(darken(@syntax-bg, 3%), 60%);
 
 
 // Official Syntax Variables -----------------------------------

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -2,33 +2,33 @@
 
 // Custom Syntax Variables -----------------------------------
 
-@syntax-cursor-line: hsla(@syntax-hue, 33%,  33%, .07); // needs to be semi-transparent to show serach results
-@syntax-bracket-matcher-background-color: darken(@syntax-background-color, 6%);
+@syntax-cursor-line: fade(@syntax-fg, 4%); // needs to be semi-transparent to show serach results
+@syntax-bracket-matcher-background-color: saturate(darken(@syntax-bg, 4%), 60%);
 
 
 // Official Syntax Variables -----------------------------------
 
 // General colors
-@syntax-text-color:            @syntax-base-text-color;
-@syntax-cursor-color:          @syntax-base-accent-color;
-@syntax-selection-color:       darken(@syntax-background-color, 8%);
-@syntax-selection-flash-color: @syntax-base-accent-color;
-@syntax-background-color:      @syntax-base-background-color;
+@syntax-text-color:            @syntax-fg;
+@syntax-cursor-color:          @syntax-accent;
+@syntax-selection-color:       darken(@syntax-bg, 5%);
+@syntax-selection-flash-color: @syntax-accent;
+@syntax-background-color:      @syntax-bg;
 
 // Guide colors
-@syntax-wrap-guide-color:          @syntax-base-guide-color;
-@syntax-indent-guide-color:        @syntax-base-guide-color;
-@syntax-invisible-character-color: @syntax-base-guide-color;
+@syntax-wrap-guide-color:          @syntax-guide;
+@syntax-indent-guide-color:        @syntax-guide;
+@syntax-invisible-character-color: @syntax-guide;
 
 // For find and replace markers
-@syntax-result-marker-color: @syntax-text-color;
-@syntax-result-marker-color-selected: @syntax-base-accent-color;
+@syntax-result-marker-color:          @syntax-fg;
+@syntax-result-marker-color-selected: @syntax-accent;
 
 // Gutter colors -----------------------------------
-@syntax-gutter-text-color: lighten(@syntax-text-color, 26%);
-@syntax-gutter-text-color-selected: @syntax-text-color;
-@syntax-gutter-background-color: @syntax-background-color; // unused
-@syntax-gutter-background-color-selected: darken(@syntax-background-color, 4%);
+@syntax-gutter-text-color:                darken(@syntax-bg, 20%);
+@syntax-gutter-text-color-selected:       saturate(darken(@syntax-bg, 60%), 20%);
+@syntax-gutter-background-color:          @syntax-bg; // unused
+@syntax-gutter-background-color-selected: darken(@syntax-bg, 3%);
 
 // Git colors - For git diff info. i.e. in the gutter
 @syntax-color-renamed:  hsl(208, 100%, 66%);
@@ -37,15 +37,15 @@
 @syntax-color-removed:  hsl(  0, 100%, 54%);
 
 // For language entity colors
-@syntax-color-variable: @red;
-@syntax-color-constant: @orange;
-@syntax-color-property: @syntax-text-color;
-@syntax-color-value: @syntax-text-color;
-@syntax-color-function: @blue;
-@syntax-color-method: @blue;
-@syntax-color-class: @light-orange;
-@syntax-color-keyword: @purple;
-@syntax-color-tag: @red;
-@syntax-color-attribute: @orange;
-@syntax-color-import: @syntax-color-keyword;
-@syntax-color-snippet: @green;
+@syntax-color-variable:   @hue-5;
+@syntax-color-constant:   @hue-6;
+@syntax-color-property:   @syntax-fg;
+@syntax-color-value:      @syntax-fg;
+@syntax-color-function:   @hue-2;
+@syntax-color-method:     @hue-2;
+@syntax-color-class:      @hue-6-2;
+@syntax-color-keyword:    @hue-3;
+@syntax-color-tag:        @hue-5;
+@syntax-color-attribute:  @hue-6;
+@syntax-color-import:     @hue-3;
+@syntax-color-snippet:    @hue-4;

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -25,7 +25,7 @@
 @syntax-result-marker-color-selected: @syntax-accent;
 
 // Gutter colors -----------------------------------
-@syntax-gutter-text-color:                darken(@syntax-bg, 20%);
+@syntax-gutter-text-color:                darken(@syntax-bg, 36%);
 @syntax-gutter-text-color-selected:       saturate(darken(@syntax-bg, 60%), 20%);
 @syntax-gutter-background-color:          @syntax-bg; // unused
 @syntax-gutter-background-color-selected: darken(@syntax-bg, 3%);


### PR DESCRIPTION
This PR makes the light theme more compatible with One dark. See https://github.com/atom/one-dark-syntax/pull/30

So in the future when there are changes to either light or dark, they can esily be ported by just copy&paste the files over. Only `colors.less` and `syntax-variables.less` will remain different. With this change the colors slightly change too.

Before:

![screen shot 2015-05-22 at 3 32 12 pm](https://cloud.githubusercontent.com/assets/378023/7765393/74999302-0098-11e5-881f-7b02f3cc6acf.png)

After:

![screen shot 2015-05-22 at 3 50 01 pm](https://cloud.githubusercontent.com/assets/378023/7765590/60d0ef44-009a-11e5-8588-ccbaef552c1c.png)
