### PR TITLE
Change .raw.inline to .raw alone in markup

### DIFF
--- a/styles/language.less
+++ b/styles/language.less
@@ -290,7 +290,7 @@
     color: @hue-6;
   }
 
-  &.raw.inline {
+  &.raw {
     color: @hue-4;
   }
 }


### PR DESCRIPTION
The inline snippet(`something`) in markdown file is marked with only `.raw`, so the current style for `.raw.inline` cannot apply to it.