### PR TITLE
Restyle find markers

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -39,6 +39,21 @@ atom-text-editor, // <- remove when Shadow DOM can't be disabled
     background-color: @syntax-wrap-guide-color;
   }
 
+  // find + replace
+  .find-result .region.region.region,
+  .current-result .region.region.region {
+    border-radius: 0px;
+    background-color: @syntax-result-marker-color;
+    transition: border-color .4s;
+  }
+  .find-result .region.region.region {
+    border: 2px solid transparent;
+  }
+  .current-result .region.region.region {
+    border: 2px solid @syntax-result-marker-color-selected;
+    transition-duration: .1s;
+  }
+
   .gutter {
 
     .line-number {

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -15,7 +15,7 @@
 @syntax-invisible-character-color: @syntax-guide;
 
 // For find and replace markers
-@syntax-result-marker-color:          @syntax-fg;
+@syntax-result-marker-color:          fade(@syntax-accent, 20%);
 @syntax-result-marker-color-selected: @syntax-accent;
 
 // Gutter colors -----------------------------------


### PR DESCRIPTION
Same as https://github.com/atom/one-dark-syntax/pull/71

![find](https://cloud.githubusercontent.com/assets/378023/16069664/2b989a80-330b-11e6-9af6-1957c5480442.gif)
