### PR TITLE
Highlight all Python operators

### DIFF
--- a/styles/syntax/python.less
+++ b/styles/syntax/python.less
@@ -1,4 +1,8 @@
 .syntax--source.syntax--python {
+  .syntax--keyword.syntax--operator.syntax--python {
+    color: @hue-2;
+  }
+
   .syntax--keyword.syntax--operator.syntax--logical.syntax--python {
     color: @hue-3;
   }


### PR DESCRIPTION
### Description of the Change

Python operators, *except* for the logical operators ('and', 'or', 'not'), which were already purple, are highlighted in blue.

### Alternate Designs

I tried making the operators bold instead and this was ugly. Blue and bold together were also ugly.

### Benefits

It makes it easier to see what goes on in complex mathematical expressions.
