### PR TITLE
Italic parameters

### DIFF
--- a/styles/syntax/python.less
+++ b/styles/syntax/python.less
@@ -1,13 +1,10 @@
 .syntax--source.syntax--python {
-  .syntax--keyword.syntax--operator.syntax--python {
-    color: @hue-2;
-  }
-
   .syntax--keyword.syntax--operator.syntax--logical.syntax--python {
     color: @hue-3;
   }
 
   .syntax--variable.syntax--parameter {
     color: @hue-6;
+    font-style: italic;
   }
 }

--- a/styles/syntax/python.less
+++ b/styles/syntax/python.less
@@ -1,4 +1,8 @@
 .syntax--source.syntax--python {
+  .syntax--keyword.syntax--operator.syntax--python {
+    color: @hue-2;
+  }
+
   .syntax--keyword.syntax--operator.syntax--logical.syntax--python {
     color: @hue-3;
   }


### PR DESCRIPTION
### Description of the Change

Function parameter names inside 'def' statements are now italic, like in Sublime Text.

### Benefits

It just plain looks better to me.

Sublime Text 

### Possible Drawbacks

Some people just don't like italics in their text editor.
