### PR TITLE
Fix TypeScript separator background colour

### DIFF
--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -232,7 +232,6 @@
   }
 
   &.syntax--separator {
-    background-color: #373b41;
     color: @mono-1;
   }
 


### PR DESCRIPTION
### Description of the Change

This removes the separator background in TypeScript.

Before | After
--- | ---
![separator](https://github-slack.s3.amazonaws.com/monosnap/Settings_2017-10-30_15-18-09.png) | ![image](https://user-images.githubusercontent.com/378023/33536634-95806a6e-d8f9-11e7-9792-d616a8ab94ce.png)

### Benefits

Doesn't look broken

### Possible Drawbacks

None

### Applicable Issues

Fixes #38
