### PR TITLE
Prevent string styling from bleeding through interpolations

### DIFF
--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -97,8 +97,8 @@
 .syntax--string {
   color: @hue-4;
 
-  > .syntax--source {
-    color: @syntax-fg;
+  > .syntax--source, .syntax--embedded {
+    color: @mono-1;
   }
 
   &.syntax--regexp {

--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -97,6 +97,10 @@
 .syntax--string {
   color: @hue-4;
 
+  > .syntax--source {
+    color: @syntax-fg;
+  }
+
   &.syntax--regexp {
     color: @hue-1;
 


### PR DESCRIPTION
### Description of the Change

Currently, interpolated code inside of strings is highlighted as a string. Not the green color on the word `three` below:

<img width="559" alt="interpolation-styling-before" src="https://user-images.githubusercontent.com/326587/42788440-62dd1dca-8914-11e8-87d6-6a7084cab591.png">

This PR explicitly resets the font color when a scope with the `source` class appears inside of a string. This works both with the TextMate highlighting and, on Atom master, with Tree-sitter highlighting as well:

<img width="581" alt="interpolation-styling-after" src="https://user-images.githubusercontent.com/326587/42788477-8e9bfc7e-8914-11e8-9019-d6c827bda4df.png">

### Alternate Designs

We could somehow cause the `string` scope to actually end at the start of the interpolation and begin again after the interpolation. I think this would be more difficult than what I've done here, with both TextMate and Tree-sitter highlighting.

### Benefits

String interpolations are easier to read.

### Possible Drawbacks

In some languages, interpolations might not be assigned the `source` class. It seems reasonable that we could change the grammars to always provide that class though.

### Applicable Issues

https://github.com/atom/language-ruby/issues/147

/cc @simurai is `@syntax-fg` the best variable to use for this purpose?